### PR TITLE
Create npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,49 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm test --if-present
+
+  publish-npm:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event.release.draft == false && github.event.release.prerelease == false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Verify release tag matches package.json version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          TAG="${TAG#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "Tag ($TAG) != package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate publishing the package to npm when a release is published. The workflow ensures that tests pass before publishing and validates that the release tag matches the version in `package.json`.

**New npm publish workflow:**

* Adds `.github/workflows/npm-publish.yml` to automate publishing to npm on new releases, including steps for checking out code, setting up Node.js, running tests, verifying the release tag matches the package version, and publishing to npm.